### PR TITLE
Workflow

### DIFF
--- a/dc.py
+++ b/dc.py
@@ -149,6 +149,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             elif topic == "WRITING":
                 self.writing.handleWritingMessage(d)
+                self.workflowTab.handleWritingMessage(d)
 
             elif topic == "TRIANGLE":
                 self.ui.triangleNchan.setValue(d["Nchan"])
@@ -188,6 +189,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             elif topic == "NUMBERWRITTEN":
                 self.writing.handleNumberWritten(d)
+                self.workflowTab.handleNumberWritten(d)
             else:
                 print("%s is not a topic we handle yet." % topic)
 

--- a/dc.py
+++ b/dc.py
@@ -131,6 +131,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.observeTab.handleStatusUpdate(d)
                 self._setGuiRunning(d["Running"], d["SourceName"])
                 self.tconfig.updateRecordLengthsFromServer(d["Nsamples"], d["Npresamp"])
+                self.workflowTab.handleStatusUpdate(d)
+
                 source = d["SourceName"]
                 nchan = d["Nchannels"]
                 if source == "Triangles":

--- a/dc.py
+++ b/dc.py
@@ -186,6 +186,8 @@ class MainWindow(QtWidgets.QMainWindow):
             elif topic == "TRIGCOUPLING":
                 self.tconfig.handleTrigCoupling(d)
 
+            elif topic == "NUMBERWRITTEN":
+                self.writing.handleNumberWritten(d)
             else:
                 print("%s is not a topic we handle yet." % topic)
 

--- a/dc.py
+++ b/dc.py
@@ -22,6 +22,7 @@ import trigger_config
 import writing
 import projectors
 import observe
+import workflow
 
 # Here is how you try to import compiled UI files and fall back to processing them
 # at load time via PyQt5.uic. But for now, with frequent changes, let's process all
@@ -63,6 +64,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.writing = writing.WritingControl(self.ui.tabWriting, host)
         self.writing.client = self.client
         self.observeTab = observe.Observe(self.ui.tabObserve)
+        self.workflowTab = workflow.Workflow(self, parent=self.ui.tabWorkflow)
 
         self.microscopes = []
         self.last_messages = defaultdict(str)

--- a/dc.py
+++ b/dc.py
@@ -73,6 +73,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.tconfig.channel_names = self.channel_names
         self.observeTab.channel_names = self.channel_names
         self.tconfig.channel_prefixes = self.channel_prefixes
+        self.workflowTab.channel_names = self.channel_names
+        self.workflowTab.channel_prefixes = self.channel_prefixes
         self.ui.launchMicroscopeButton.clicked.connect(self.launchMicroscope)
         self.ui.killAllMicroscopesButton.clicked.connect(self.killAllMicroscopes)
         self.ui.tabWidget.setEnabled(False)

--- a/dc.ui
+++ b/dc.ui
@@ -133,7 +133,7 @@
         <item>
          <widget class="QStackedWidget" name="dataSourcesStackedWidget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <widget class="QWidget" name="trianglePage">
            <widget class="QFrame" name="gridFrame">
@@ -578,6 +578,11 @@
          </layout>
         </item>
        </layout>
+      </widget>
+      <widget class="QWidget" name="tabWorkflow">
+       <attribute name="title">
+        <string>Workflow</string>
+       </attribute>
       </widget>
       <widget class="QWidget" name="tabTriggering">
        <attribute name="title">

--- a/workflow.py
+++ b/workflow.py
@@ -46,11 +46,12 @@ class Workflow(QtWidgets.QWidget):
         self.NumberOfChans = None # to be set by handleNumberWritten
         self.currentlyWriting = None # to be set by handleWritingMessage
         self.reset()
-        self.testingInit() # REMOVE
+        # self.testingInit() # REMOVE
 
     def testingInit(self):
         """
         pre-populate the output of some steps for faster testing
+        to be removed
         """
         self.noiseFilename = "/tmp/20180709/0001/20180709_run0001_chan*.ljh"
         self.pulseFilename = "/tmp/20180709/0000/20180709_run0000_chan*.ljh"

--- a/workflow.py
+++ b/workflow.py
@@ -6,10 +6,18 @@ from PyQt5.QtCore import QObject, pyqtSignal, Qt, QTimer
 import numpy as np
 import json
 import time
+import subprocess
+import os
+import glob
+import sys
 
 Ui_Workflow, _ = PyQt5.uic.loadUiType("workflow.ui")
 
-
+POPE_PATH = os.path.expanduser("~/.julia/v0.6/Pope/Scripts")
+NOISE_ANALYSIS_PATH = os.path.join(POPE_PATH,"noise_analysis.jl")
+BASIS_CREATE_PATH = os.path.join(POPE_PATH,"basis_create.jl")
+NOISE_PLOT_PATH = os.path.join(POPE_PATH,"noise_plots.jl")
+BASIS_PLOT_PATH = os.path.join(POPE_PATH,"basis_plots.jl")
 class Workflow(QtWidgets.QWidget):
     """The tricky bit about this widget is that it cannot be properly set up until
     dc has processed both a CHANNELNAMES message and a STATUS message (to get the
@@ -24,15 +32,38 @@ class Workflow(QtWidgets.QWidget):
         self.ui.pushButton_createNoiseModel.clicked.connect(self.handleCreateNoiseModel)
         self.ui.pushButton_createProjectors.clicked.connect(self.handleCreateProjectors)
         self.ui.pushButton_loadProjectors.clicked.connect(self.handleLoadProjectors)
+        self.ui.pushButton_viewNoisePlot.clicked.connect(self.handleViewNoisePlot)
         self.dc = dc
         self.channel_names = None # to be overwritten by dc.py
         self.channel_prefixes = None  # to be overwritten by dc.py
+        self.testingInit()
+
+    def testingInit(self):
+        """
+        pre-populate the output of some steps for faster testing
+        """
+        self.noiseFilename = "/tmp/20180706/0007/20180706_run0007_chan*.ljh"
+        self.pulseFilename = "/tmp/20180706/0008/20180706_run0008_chan*.ljh"
+        self.ui.label_noiseFile.setText("current noise file: %s"%self.noiseFilename)
+        self.ui.label_pulseFile.setText("current noise file: %s"%self.pulseFilename)
+
+    def reset(self):
+        self.noiseFilename = None
+        self.ui.label_noiseFile.setText("noise data: %s"%self.noiseFilename)
+        self.pulseFilename = None
+        self.ui.label_pulseFile.setText("pulse data: %s"%self.pulseFilename)
+        self.noiseModelFilename = None
+        self.ui.label_noiseModel.setText("noise model: %s"%self.noiseModelFilename)
+        self.noisePlotFilename = None
+        self.ui.pushButton_viewNoisePlot.setEnabled(False)
+
 
     def handleTakeNoise(self):
         """
         take noise data, record filename for future use
         """
         # set triggers to auto for all fb channels
+        self.reset()
         print self.channel_names
         state = {}
         state["ChanNumbers"]=[chan for (chan,name) in enumerate(self.channel_names) if name.startswith("chan")]
@@ -44,17 +75,17 @@ class Workflow(QtWidgets.QWidget):
         self.dc.writing.start()
         # wait for 1000 records/channels
         # dont know how to do this yet, so lets just wait for 3 seconds
-        TIME_UNITS_TO_WAIT = 30
+        TIME_UNITS_TO_WAIT = 4
         # arguments are label text, cancel button text, minimum value, maximum value
         # None for cancel button text makes there be no cancel button
-        progressBar = QtWidgets.QProgressDialog("taking noise...",None,0,TIME_UNITS_TO_WAIT-1,parent=self)
+        progressBar = QtWidgets.QProgressDialog("taking pulses (not really, just placeholder code)...",None,0,TIME_UNITS_TO_WAIT-1,parent=self)
         progressBar.setModal(True) # prevent users from clicking elsewhere in gui
         progressBar.show()
         for i in range(TIME_UNITS_TO_WAIT):
             time.sleep(0.1)
             # remember filenames
             self.noiseFilename = self.dc.writing.ui.fileNameExampleEdit.text()
-            self.ui.label_noiseFile.setText("current noise file: %s"%self.noiseFilename)
+            self.ui.label_noiseFile.setText("noise data: %s"%self.noiseFilename)
             progressBar.setValue(i)
             QtWidgets.QApplication.processEvents() # process gui events
         progressBar.close()
@@ -63,18 +94,88 @@ class Workflow(QtWidgets.QWidget):
         self.dc.writing.stop()
 
     def handleTakePulses(self):
-        # set triggers to pulse triggers for all fb channels
-        # start writing files`
-        # wait for 3000 records/channels
-        # stop writing files
-        # remember filename
-        raise Exception("not implemented")
+        """
+        take noise data, record filename for future use
+        """
+        # set triggers to auto for all fb channels
+        # this is wrong!!! but I need something here to make progress
+        # the best option would be to have Joe implement the "trigger states" buttons
+        # and activate the pulses trigger state
+        print self.channel_names
+        state = {}
+        state["ChanNumbers"]=[chan for (chan,name) in enumerate(self.channel_names) if name.startswith("chan")]
+        state["AutoTrigger"]=True
+        state["AutoDelay"]=0
+        print state
+        self.dc.client.call("SourceControl.ConfigureTriggers", state)
+        # start writing files
+        self.dc.writing.start()
+        # wait for 1000 records/channels
+        # dont know how to do this yet, so lets just wait for 3 seconds
+        # its more important than in the noise case to count written records
+        TIME_UNITS_TO_WAIT = 4
+        # arguments are label text, cancel button text, minimum value, maximum value
+        # None for cancel button text makes there be no cancel button
+        progressBar = QtWidgets.QProgressDialog("taking pulses...",None,0,TIME_UNITS_TO_WAIT-1,parent=self)
+        progressBar.setModal(True) # prevent users from clicking elsewhere in gui
+        progressBar.show()
+        for i in range(TIME_UNITS_TO_WAIT):
+            time.sleep(0.1)
+            # remember filenames
+            self.pulseFilename = self.dc.writing.ui.fileNameExampleEdit.text()
+            self.ui.label_pulseFile.setText("pulse data: %s"%self.pulseFilename)
+            progressBar.setValue(i)
+            QtWidgets.QApplication.processEvents() # process gui events
+        progressBar.close()
+
+        # # stop writing files
+        self.dc.writing.stop()
 
     def handleCreateNoiseModel(self):
-        # call pope script
-        # remember filename
-        # button to view plots
-        raise Exception("not implemented")
+        # create output file name (easier than getting it from script output?)
+        # output
+        # create pope script call
+        outName = self.noiseFilename[:-9]+"noise.hdf5"
+        plotName = self.noiseFilename[:-9]+"noise.pdf"
+        print outName
+        inputFiles = glob.glob(self.noiseFilename)
+        cmd = ["julia",NOISE_ANALYSIS_PATH,"-u"] + inputFiles
+        # -u instructs noise_analysis to "update" the file by adding new channels, this shouldn't be
+        # neccesary but it doesn't seem to work without it
+        print(repr(cmd)+"\n")
+        if len(inputFiles) == 0:
+            print("found no input files for {}".format(self.noiseFilename))
+        elif os.path.isfile(outName):
+            print("{} already exists, skipping noise_analysis.jl".format(outName))
+        else:
+            # check_output throws an error if the process fails
+            output = subprocess.check_output(cmd)
+            print(output)
+        self.noiseModelFilename = outName
+        self.ui.label_noiseModel.setText("noise model: %s"%self.noiseModelFilename)
+
+        cmdPlot = ["julia",NOISE_PLOT_PATH, plotName]
+        print(repr(cmdPlot)+"\n")
+        if os.path.isfile(plotName):
+            print("{} already exists, skipping noise_plots.jl".format(plotName))
+        else:
+            cmdOutput = subprocess.check_output(cmdPlot)
+            print(cmdOutput)
+
+        self.noisePlotFilename = plotName
+        self.ui.pushButton_viewNoisePlot.setEnabled(True)
+
+    def handleViewNoisePlot(self):
+        print sys.platform
+        print self.noisePlotFilename
+        if sys.platform.startswith('darwin'):
+            cmd = ["open", self.noisePlotFilename]
+        elif sys.platform.startswith('linux'):
+            cmd = ["evince", self.noisePlotFilename]
+        else:
+            raise Exception("pdf view not implement for platform = {}".format(sys.platform))
+        print(repr(cmd)+"\n")
+        subprocess.Popen(cmd)
 
     def handleCreateProjectors(self):
         # call pope script

--- a/workflow.py
+++ b/workflow.py
@@ -1,11 +1,11 @@
 # Qt5 imports
 import PyQt5.uic
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import QObject, pyqtSignal, Qt
+from PyQt5.QtCore import QObject, pyqtSignal, Qt, QTimer
 
 import numpy as np
 import json
-from matplotlib import cm
+import time
 
 Ui_Workflow, _ = PyQt5.uic.loadUiType("workflow.ui")
 
@@ -25,18 +25,82 @@ class Workflow(QtWidgets.QWidget):
         self.ui.pushButton_createProjectors.clicked.connect(self.handleCreateProjectors)
         self.ui.pushButton_loadProjectors.clicked.connect(self.handleLoadProjectors)
         self.dc = dc
+        self.channel_names = None # to be overwritten by dc.py
+        self.channel_prefixes = None  # to be overwritten by dc.py
 
     def handleTakeNoise(self):
-        raise Exception("not implemented")
+        """
+        take noise data, record filename for future use
+        """
+        # set triggers to auto for all fb channels
+        print self.channel_names
+        state = {}
+        state["ChanNumbers"]=[chan for (chan,name) in enumerate(self.channel_names) if name.startswith("chan")]
+        state["AutoTrigger"]=True
+        state["AutoDelay"]=0
+        print state
+        self.dc.client.call("SourceControl.ConfigureTriggers", state)
+        # start writing files
+        self.dc.writing.start()
+        # wait for 1000 records/channels
+        # dont know how to do this yet, so lets just wait for 3 seconds
+        TIME_UNITS_TO_WAIT = 30
+        # arguments are label text, cancel button text, minimum value, maximum value
+        # None for cancel button text makes there be no cancel button
+        progressBar = QtWidgets.QProgressDialog("taking noise...",None,0,TIME_UNITS_TO_WAIT-1,parent=self)
+        progressBar.setModal(True) # prevent users from clicking elsewhere in gui
+        progressBar.show()
+        for i in range(TIME_UNITS_TO_WAIT):
+            time.sleep(0.1)
+            # remember filenames
+            self.noiseFilename = self.dc.writing.ui.fileNameExampleEdit.text()
+            self.ui.label_noiseFile.setText("current noise file: %s"%self.noiseFilename)
+            progressBar.setValue(i)
+            QtWidgets.QApplication.processEvents() # process gui events
+        progressBar.close()
+
+        # # stop writing files
+        self.dc.writing.stop()
 
     def handleTakePulses(self):
+        # set triggers to pulse triggers for all fb channels
+        # start writing files`
+        # wait for 3000 records/channels
+        # stop writing files
+        # remember filename
         raise Exception("not implemented")
 
     def handleCreateNoiseModel(self):
+        # call pope script
+        # remember filename
+        # button to view plots
         raise Exception("not implemented")
 
     def handleCreateProjectors(self):
+        # call pope script
+        # remember filename
+        # button to view plots
         raise Exception("not implemented")
 
     def handleLoadProjectors(self):
+        # load projectors
         raise Exception("not implemented")
+
+
+if __name__ == "__main__":
+    import sys
+
+
+    app = QtWidgets.QApplication(sys.argv)
+    bar = QtWidgets.QProgressDialog("taking noise...",None,0,30,parent=None)
+    # bar.setWindowModality(PyQt5.WindowModal)
+    bar.show()
+
+    i = 0
+    while not bar.wasCanceled():
+        time.sleep(0.1)
+        # remember filesnames
+        i+=1
+        bar.setValue(i)
+
+    sys.exit(app.exec_())

--- a/workflow.py
+++ b/workflow.py
@@ -86,7 +86,7 @@ class Workflow(QtWidgets.QWidget):
         self.dc.writing.start()
         # wait for 1000 records/channels
         # dont know how to do this yet, so lets just wait for 3 seconds
-        TIME_UNITS_TO_WAIT = 4
+        TIME_UNITS_TO_WAIT = 30
         # arguments are label text, cancel button text, minimum value, maximum value
         # None for cancel button text makes there be no cancel button
         progressBar = QtWidgets.QProgressDialog("taking pulses (not really, just placeholder code)...",None,0,TIME_UNITS_TO_WAIT-1,parent=self)
@@ -125,7 +125,7 @@ class Workflow(QtWidgets.QWidget):
         # wait for 1000 records/channels
         # dont know how to do this yet, so lets just wait for 3 seconds
         # its more important than in the noise case to count written records
-        TIME_UNITS_TO_WAIT = 4
+        TIME_UNITS_TO_WAIT = 6000
         # arguments are label text, cancel button text, minimum value, maximum value
         # None for cancel button text makes there be no cancel button
         progressBar = QtWidgets.QProgressDialog("taking pulses...",None,0,TIME_UNITS_TO_WAIT-1,parent=self)

--- a/workflow.py
+++ b/workflow.py
@@ -1,0 +1,42 @@
+# Qt5 imports
+import PyQt5.uic
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtCore import QObject, pyqtSignal, Qt
+
+import numpy as np
+import json
+from matplotlib import cm
+
+Ui_Workflow, _ = PyQt5.uic.loadUiType("workflow.ui")
+
+
+class Workflow(QtWidgets.QWidget):
+    """The tricky bit about this widget is that it cannot be properly set up until
+    dc has processed both a CHANNELNAMES message and a STATUS message (to get the
+    number of rows and columns)."""
+
+    def __init__(self, dc, parent=None):
+        QtWidgets.QWidget.__init__(self, parent)
+        self.ui = Ui_Workflow()
+        self.ui.setupUi(self)
+        self.ui.pushButton_takeNoise.clicked.connect(self.handleTakeNoise)
+        self.ui.pushButton_takePulses.clicked.connect(self.handleTakePulses)
+        self.ui.pushButton_createNoiseModel.clicked.connect(self.handleCreateNoiseModel)
+        self.ui.pushButton_createProjectors.clicked.connect(self.handleCreateProjectors)
+        self.ui.pushButton_loadProjectors.clicked.connect(self.handleLoadProjectors)
+        self.dc = dc
+
+    def handleTakeNoise(self):
+        raise Exception("not implemented")
+
+    def handleTakePulses(self):
+        raise Exception("not implemented")
+
+    def handleCreateNoiseModel(self):
+        raise Exception("not implemented")
+
+    def handleCreateProjectors(self):
+        raise Exception("not implemented")
+
+    def handleLoadProjectors(self):
+        raise Exception("not implemented")

--- a/workflow.ui
+++ b/workflow.ui
@@ -18,7 +18,7 @@
     <rect>
      <x>20</x>
      <y>20</y>
-     <width>406</width>
+     <width>691</width>
      <height>41</height>
     </rect>
    </property>
@@ -38,7 +38,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_6">
+     <widget class="QLabel" name="label_noiseFile">
       <property name="text">
        <string>current pulses file:</string>
       </property>
@@ -51,7 +51,7 @@
     <rect>
      <x>20</x>
      <y>60</y>
-     <width>406</width>
+     <width>691</width>
      <height>41</height>
     </rect>
    </property>
@@ -84,7 +84,7 @@
     <rect>
      <x>20</x>
      <y>100</y>
-     <width>406</width>
+     <width>691</width>
      <height>41</height>
     </rect>
    </property>
@@ -117,7 +117,7 @@
     <rect>
      <x>20</x>
      <y>140</y>
-     <width>406</width>
+     <width>691</width>
      <height>41</height>
     </rect>
    </property>
@@ -150,7 +150,7 @@
     <rect>
      <x>20</x>
      <y>180</y>
-     <width>406</width>
+     <width>691</width>
      <height>41</height>
     </rect>
    </property>

--- a/workflow.ui
+++ b/workflow.ui
@@ -182,7 +182,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_14">
+     <widget class="QLabel" name="label_loadedProjectors">
       <property name="text">
        <string>loaded?: no</string>
       </property>

--- a/workflow.ui
+++ b/workflow.ui
@@ -146,7 +146,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_12">
+     <widget class="QLabel" name="label_projectors">
       <property name="text">
        <string>projectors file:</string>
       </property>
@@ -207,6 +207,22 @@
    </property>
    <property name="text">
     <string>View Noise Plots</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButton_viewProjectorsPlot">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>90</x>
+     <y>320</y>
+     <width>161</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>View Projectors Plots</string>
    </property>
   </widget>
  </widget>

--- a/workflow.ui
+++ b/workflow.ui
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>842</width>
+    <height>485</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QWidget" name="horizontalLayoutWidget_3">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>20</y>
+     <width>406</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <item>
+     <widget class="QLabel" name="label_5">
+      <property name="text">
+       <string>1.</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushButton_takeNoise">
+      <property name="text">
+       <string>Take Noise</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="label_6">
+      <property name="text">
+       <string>current pulses file:</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget_4">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>60</y>
+     <width>406</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_4">
+    <item>
+     <widget class="QLabel" name="label_7">
+      <property name="text">
+       <string>2.</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushButton_takePulses">
+      <property name="text">
+       <string>Take Pulses</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="label_8">
+      <property name="text">
+       <string>current pulses file:</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget_5">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>100</y>
+     <width>406</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_5">
+    <item>
+     <widget class="QLabel" name="label_9">
+      <property name="text">
+       <string>3.</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushButton_createNoiseModel">
+      <property name="text">
+       <string>Create Noise Model</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="label_10">
+      <property name="text">
+       <string>current pulses file:</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget_6">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>140</y>
+     <width>406</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_6">
+    <item>
+     <widget class="QLabel" name="label_11">
+      <property name="text">
+       <string>4.</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushButton_createProjectors">
+      <property name="text">
+       <string>Create Projectors</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="label_12">
+      <property name="text">
+       <string>current pulses file:</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget_7">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>180</y>
+     <width>406</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_7">
+    <item>
+     <widget class="QLabel" name="label_13">
+      <property name="text">
+       <string>5.</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushButton_loadProjectors">
+      <property name="text">
+       <string>Load Projectors</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="label_14">
+      <property name="text">
+       <string>current pulses file:</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/workflow.ui
+++ b/workflow.ui
@@ -40,7 +40,10 @@
     <item>
      <widget class="QLabel" name="label_noiseFile">
       <property name="text">
-       <string>current pulses file:</string>
+       <string>noise data:</string>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
@@ -71,9 +74,12 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_8">
+     <widget class="QLabel" name="label_pulseFile">
       <property name="text">
-       <string>current pulses file:</string>
+       <string>pulse file:</string>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
@@ -104,9 +110,12 @@
      </widget>
     </item>
     <item>
-     <widget class="QLabel" name="label_10">
+     <widget class="QLabel" name="label_noiseModel">
       <property name="text">
-       <string>current pulses file:</string>
+       <string>noise model:</string>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
@@ -139,7 +148,10 @@
     <item>
      <widget class="QLabel" name="label_12">
       <property name="text">
-       <string>current pulses file:</string>
+       <string>projectors file:</string>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
@@ -172,11 +184,30 @@
     <item>
      <widget class="QLabel" name="label_14">
       <property name="text">
-       <string>current pulses file:</string>
+       <string>loaded?: no</string>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
    </layout>
+  </widget>
+  <widget class="QPushButton" name="pushButton_viewNoisePlot">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>90</x>
+     <y>290</y>
+     <width>131</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>View Noise Plots</string>
+   </property>
   </widget>
  </widget>
  <resources/>

--- a/writing.py
+++ b/writing.py
@@ -57,6 +57,19 @@ class WritingControl(QtWidgets.QWidget):
         if len(result) > 0:
             self.updatePath(result)
 
+
+    def start(self):
+        if self.writing:
+            raise Exception("already writing")
+        else:
+            self.startstop()
+
+    def stop(self):
+        if not self.writing:
+            raise Exception("already stopped")
+        else:
+            self.startstop()
+
     def startstop(self):
         if self.writing:
             request = {"Request": "Stop"}
@@ -74,6 +87,7 @@ class WritingControl(QtWidgets.QWidget):
             print "Could not %s writing: " % request["Request"], e
 
     def stoppedWriting(self):
+        print "STOPPED WRITING"
         self.writing = False
         self.ui.writingStartButton.setText("Start Writing")
         self.ui.previousNameExampleEdit.setText(self.ui.fileNameExampleEdit.text())
@@ -82,6 +96,7 @@ class WritingControl(QtWidgets.QWidget):
         self.ui.writingPauseButton.setEnabled(False)
 
     def startedWriting(self, example):
+        print "STARTED WRITING"
         self.writing = True
         self.ui.writingStartButton.setText("Stop Writing")
         self.ui.fileNameExampleEdit.setText(example)

--- a/writing.py
+++ b/writing.py
@@ -3,8 +3,9 @@ import PyQt5.uic
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import QObject, pyqtSignal, Qt
 
-Ui_Writing, _ = PyQt5.uic.loadUiType("writing.ui")
+import numpy as np
 
+Ui_Writing, _ = PyQt5.uic.loadUiType("writing.ui")
 
 class WritingControl(QtWidgets.QWidget):
     """Provide the UI inside the Triggering tab.
@@ -57,6 +58,9 @@ class WritingControl(QtWidgets.QWidget):
         if len(result) > 0:
             self.updatePath(result)
 
+    def handleNumberWritten(self, d):
+        self.ui.label_numberWritten.setText("Number Written by Channel: {}\nNumber Written Total: {}".format(d["NumberWritten"],
+                                            np.sum(d["NumberWritten"])))
 
     def start(self):
         if self.writing:

--- a/writing.ui
+++ b/writing.ui
@@ -115,6 +115,19 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QLabel" name="label_numberWritten">
+     <property name="text">
+      <string>Records Written: none</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
Creates a "Workflow" tab that works through setting projectors. Very much experimental, but I think this is a good direction. Also fixes #25 with a very simple display of number written on writing tab. Still need to figure out calibration, but I think the plan is:
1. Write a python script that loads the projectors and the pulse files, and does the projections, and learns a calibration from that.
2. Load this into dastard.
3. Teach dastard to know about calibrations and publish messages like [channel, timestamp, rowcount, energy]
![mainwindow](https://user-images.githubusercontent.com/5192577/42480637-b3ff7a50-839b-11e8-845f-ebb5eecf536f.png)
