### PR TITLE
Handle server restarts

### DIFF
--- a/dc.py
+++ b/dc.py
@@ -473,21 +473,21 @@ class MainWindow(QtWidgets.QMainWindow):
             return
 
     def _startTriangle(self):
-            config = {
-                "Nchan": self.ui.triangleNchan.value(),
-                "SampleRate": self.ui.triangleSampleRate.value(),
-                "Max": self.ui.triangleMaximum.value(),
-                "Min": self.ui.triangleMinimum.value(),
-            }
-            okay = self.client.call("SourceControl.ConfigureTriangleSource", config)
-            if not okay:
-                print "Could not ConfigureTriangleSource"
-                return
-            okay = self.client.call("SourceControl.Start", "TRIANGLESOURCE")
-            if not okay:
-                print "Could not Start Triangle "
-                return
-            print "Starting Triangle"
+        config = {
+            "Nchan": self.ui.triangleNchan.value(),
+            "SampleRate": self.ui.triangleSampleRate.value(),
+            "Max": self.ui.triangleMaximum.value(),
+            "Min": self.ui.triangleMinimum.value(),
+        }
+        okay = self.client.call("SourceControl.ConfigureTriangleSource", config)
+        if not okay:
+            print "Could not ConfigureTriangleSource"
+            return
+        okay = self.client.call("SourceControl.Start", "TRIANGLESOURCE")
+        if not okay:
+            print "Could not Start Triangle "
+            return
+        print "Starting Triangle"
 
     def _startSimPulse(self):
         config = {

--- a/dc.py
+++ b/dc.py
@@ -119,6 +119,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.hbTimer.timeout.connect(lambda: self.closeReconnect("missing heartbeat"))
         self.hbTimeout = 5000  # that is, 5000 ms
         self.hbTimer.start(self.hbTimeout)
+        self.fully_configured = False
 
     @pyqtSlot(str, str)
     def updateReceived(self, topic, message):
@@ -206,10 +207,16 @@ class MainWindow(QtWidgets.QMainWindow):
             elif topic == "NUMBERWRITTEN":
                 self.writingTab.handleNumberWritten(d)
                 self.workflowTab.handleNumberWritten(d)
+
+            elif topic == "NEWDASTARD":
+                if self.fully_configured:
+                    self.fully_configured = False
+                    self.closeReconnect("New Dastard started")
+
             else:
                 print("%s is not a topic we handle yet." % topic)
 
-        quietTopics = set(["TRIGGERRATE","NUMBERWRITTEN","ALIVE"])
+        quietTopics = set(["TRIGGERRATE", "NUMBERWRITTEN", "ALIVE"])
         if topic not in quietTopics or self.nmsg < 15:
             print("%s %5d: %s" % (topic, self.nmsg, d))
 
@@ -224,6 +231,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 allseen = False
                 break
         if allseen:
+            self.fully_configured = True
             self.ui.tabWidget.setEnabled(True)
 
     def buildStatusBar(self):
@@ -462,7 +470,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _start(self):
         sourceID = self.ui.dataSource.currentIndex()
-        # These only make sense for Lancero
         if sourceID == 0:
             self._startTriangle()
         elif sourceID == 1:

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -35,17 +35,23 @@ class JSONClient(object):
             print("SENDING")
             print(json.dumps(params,indent=4))
         request = self._message(name, params)
-        id = request.get('id')
+        reqid = request.get('id')
         msg = self._codec.dumps(request)
         self._socket.sendall(msg.encode())
 
-        # This will actually have to loop if resp is bigger
+        # This will actually have to loop if resp is bigger than 4096 bytes
         response = self._socket.recv(4096)
-        response = self._codec.loads(response.decode())
+        try:
+            response = self._codec.loads(response.decode())
+        except ValueError:  # This means RPC server is gone
+            print "RPC server is missing."
+            self.qtParent.reconnect = True
+            self.close()
+            return None
 
-        if response.get('id') != id:
-            raise Exception("expected id=%s, received id=%s: %s" %
-                            (id, response.get('id'),
+        if response.get('id') != reqid:
+            raise ValueError("JSON-RPC expected id=%s, received id=%s: %s" %
+                            (reqid, response.get('id'),
                              response.get('error')))
 
         if response.get('error') is not None:
@@ -61,5 +67,7 @@ class JSONClient(object):
         return response.get('result')
 
     def close(self):
-        self._closed = True
-        self._socket.close()
+        if not self._closed:
+            self._closed = True
+            self._socket.close()
+            self.qtParent.close()

--- a/trigger_config.py
+++ b/trigger_config.py
@@ -33,7 +33,7 @@ class TriggerConfig(QtWidgets.QWidget):
                             self.ui.edgeEdit]
 
     def _closing(self):
-        """The main window calls this to block and editingFinished events from
+        """The main window calls this to block any editingFinished events from
         being processed when the main window is closing."""
         for w in self.editWidgets:
             w.blockSignals(True)


### PR DESCRIPTION
Fixes #35 by handling the new NEWDASTARD message. Also handles RPC failures (which are mostly gone, because of the NEWDASTARD message) by closing and restarting dastard-commander.