### PR TITLE
Turn off error easier

### DIFF
--- a/dc.py
+++ b/dc.py
@@ -449,7 +449,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._setGuiRunning(True)
 
     def _stop(self):
-        okay = self.client.call("SourceControl.Stop", "")
+        okay, error = self.client.call("SourceControl.Stop", "")
         if not okay:
             print "Could not Stop data"
             return
@@ -491,11 +491,11 @@ class MainWindow(QtWidgets.QMainWindow):
             "Max": self.ui.triangleMaximum.value(),
             "Min": self.ui.triangleMinimum.value(),
         }
-        okay = self.client.call("SourceControl.ConfigureTriangleSource", config)
+        okay, error = self.client.call("SourceControl.ConfigureTriangleSource", config)
         if not okay:
             print "Could not ConfigureTriangleSource"
             return
-        okay = self.client.call("SourceControl.Start", "TRIANGLESOURCE")
+        okay, error = self.client.call("SourceControl.Start", "TRIANGLESOURCE")
         if not okay:
             print "Could not Start Triangle "
             return
@@ -509,11 +509,11 @@ class MainWindow(QtWidgets.QMainWindow):
             "Pedestal": self.ui.simPulseBaseline.value(),
             "Nsamp": self.ui.simPulseSamplesPerPulse.value(),
         }
-        okay = self.client.call("SourceControl.ConfigureSimPulseSource", config)
+        okay, error = self.client.call("SourceControl.ConfigureSimPulseSource", config)
         if not okay:
             print "Could not ConfigureSimPulseSource"
             return
-        okay = self.client.call("SourceControl.Start", "SIMPULSESOURCE")
+        okay, error = self.client.call("SourceControl.Start", "SIMPULSESOURCE")
         if not okay:
             print "Could not Start SimPulse"
             return
@@ -568,18 +568,18 @@ class MainWindow(QtWidgets.QMainWindow):
         if fileName:
             self.lastdir = os.path.dirname(fileName)
             print("opening: {}".format(fileName))
-            configs = projectors.getConfigs(fileName)
+            configs = projectors.getConfigs(fileName, self.channel_names)
             print("Sending model for {} chans".format(len(configs)))
             success_chans = []
             failures = OrderedDict()
-            for channum, config in configs.items():
-                print("sending ProjectorsBasis for {}".format(channum))
-                try:
-                    self.client.call("SourceControl.ConfigureProjectorsBasis", config, verbose=False, errorBox=False)
-                    success_chans.append(channum)
-                except Exception as ex:
-                    failures[channum] = ex.args[0]
-            result = "success on chans: {}\n".format(success_chans) + "failures:\n" + json.dumps(failures, sort_keys=True, indent=4)
+            for channelIndex, config in configs.items():
+                print("sending ProjectorsBasis for {}".format(channelIndex))
+                okay, error = self.client.call("SourceControl.ConfigureProjectorsBasis", config, verbose=False, errorBox=False, throwError=False)
+                if okay:
+                    success_chans.append(channelIndex)
+                else:
+                    failures[channelIndex] = error
+            result = "success on channelIndicies (not channelName): {}\n".format(sorted(success_chans)) + "failures:\n" + json.dumps(failures, sort_keys=True, indent=4)
             resultBox = QtWidgets.QMessageBox(self)
             resultBox.setText(result)
             resultBox.show()
@@ -588,7 +588,7 @@ class MainWindow(QtWidgets.QMainWindow):
     @pyqtSlot()
     def sendEdgeMulti(self):
         config = {
-            "ChannelIndicies": range(len(self.channel_names)),
+            "ChannelIndicies": range(1,len(self.channel_names),2), # hardcode lancero only behavior of odd channels for now
             "EdgeMulti": self.ui.checkBox_EdgeMulti.isChecked(),
             "EdgeRising": self.ui.checkBox_EdgeMulti.isChecked(),
             "EdgeTrigger": self.ui.checkBox_EdgeMulti.isChecked(),

--- a/dc.py
+++ b/dc.py
@@ -544,6 +544,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "Nsamp": nsamp,
             "ActiveCards": activate,
             "AvailableCards": []   # This is filled in only by server, not us.
+            "AutoRestart" : self.ui.checkBox_lanceroAutoRestart.isChecked()
         }
         print "START LANCERO CONFIG"
         print config
@@ -598,6 +599,9 @@ class MainWindow(QtWidgets.QMainWindow):
             "EdgeLevel": self.ui.spinBox_EdgeLevel.value()
         }
         self.client.call("SourceControl.ConfigureTriggers", config)
+        if not self.ui.checkBox_edgeMultiTriggerOnError.isChecked():
+            config = {"ChannelIndicies": range(0,len(self.channel_names),2)}
+            self.client.call("SourceControl.ConfigureTriggers", config)
 
     @pyqtSlot()
     def sendMix(self):

--- a/dc.py
+++ b/dc.py
@@ -588,7 +588,7 @@ class MainWindow(QtWidgets.QMainWindow):
     @pyqtSlot()
     def sendEdgeMulti(self):
         config = {
-            "ChannelIndicies": range(1,len(self.channel_names),2), # hardcode lancero only behavior of odd channels for now
+            "ChannelIndicies": range(len(self.channel_names)), 
             "EdgeMulti": self.ui.checkBox_EdgeMulti.isChecked(),
             "EdgeRising": self.ui.checkBox_EdgeMulti.isChecked(),
             "EdgeTrigger": self.ui.checkBox_EdgeMulti.isChecked(),

--- a/dc.py
+++ b/dc.py
@@ -543,7 +543,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "CardDelay": delays,
             "Nsamp": nsamp,
             "ActiveCards": activate,
-            "AvailableCards": []   # This is filled in only by server, not us.
+            "AvailableCards": [],   # This is filled in only by server, not us.
             "AutoRestart" : self.ui.checkBox_lanceroAutoRestart.isChecked()
         }
         print "START LANCERO CONFIG"

--- a/dc.ui
+++ b/dc.ui
@@ -720,12 +720,15 @@
              <property name="maximum">
               <number>65000</number>
              </property>
+             <property name="minimum">
+              <number>-65000</number>
+             </property>
             </widget>
            </item>
            <item>
             <widget class="QLabel" name="label_17">
              <property name="text">
-              <string>Threshold</string>
+              <string>Threshold (negative for negative edges)</string>
              </property>
             </widget>
            </item>

--- a/dc.ui
+++ b/dc.ui
@@ -391,52 +391,11 @@
              <rect>
               <x>0</x>
               <y>20</y>
-              <width>351</width>
+              <width>386</width>
               <height>311</height>
              </rect>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="1">
-              <layout class="QGridLayout" name="gridLayout_4">
-               <item row="2" column="1">
-                <widget class="QPushButton" name="noFibersButton">
-                 <property name="text">
-                  <string>None</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0" colspan="2">
-                <widget class="QLabel" name="label_15">
-                 <property name="text">
-                  <string>Fiber Select</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0" colspan="2">
-                <widget class="QCheckBox" name="parallelStreaming">
-                 <property name="text">
-                  <string>Parallel Streaming</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QPushButton" name="allFibersButton">
-                 <property name="text">
-                  <string>All</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0" colspan="2">
-                <layout class="QGridLayout" name="lanceroFiberLayout"/>
-               </item>
-              </layout>
-             </item>
              <item row="0" column="0">
               <layout class="QVBoxLayout" name="verticalLayout_3">
                <item>
@@ -530,6 +489,13 @@
                    <property name="topMargin">
                     <number>0</number>
                    </property>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_16">
+                     <property name="text">
+                      <string>Error Nsamp</string>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="1" column="1">
                     <widget class="QSpinBox" name="nsampSpinBox">
                      <property name="toolTip">
@@ -550,16 +516,57 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_16">
+                   <item row="2" column="0">
+                    <widget class="QCheckBox" name="checkBox_lanceroAutoRestart">
                      <property name="text">
-                      <string>Error Nsamp</string>
+                      <string>Auto Restart (not working)</string>
                      </property>
                     </widget>
                    </item>
                   </layout>
                  </item>
                 </layout>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="1">
+              <layout class="QGridLayout" name="gridLayout_4">
+               <item row="2" column="1">
+                <widget class="QPushButton" name="noFibersButton">
+                 <property name="text">
+                  <string>None</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0" colspan="2">
+                <widget class="QLabel" name="label_15">
+                 <property name="text">
+                  <string>Fiber Select</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0" colspan="2">
+                <widget class="QCheckBox" name="parallelStreaming">
+                 <property name="text">
+                  <string>Parallel Streaming</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QPushButton" name="allFibersButton">
+                 <property name="text">
+                  <string>All</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0" colspan="2">
+                <layout class="QGridLayout" name="lanceroFiberLayout"/>
                </item>
               </layout>
              </item>
@@ -688,7 +695,7 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="7" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_4">
            <item>
             <widget class="QSpinBox" name="spinBox_EdgeMultiVerifyNMonotone">
@@ -706,7 +713,7 @@
            </item>
           </layout>
          </item>
-         <item row="7" column="0">
+         <item row="8" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
             <widget class="QSpinBox" name="spinBox_EdgeLevel">
@@ -724,7 +731,7 @@
            </item>
           </layout>
          </item>
-         <item row="8" column="0">
+         <item row="9" column="0">
           <widget class="QPushButton" name="pushButton_sendEdgeMulti">
            <property name="text">
             <string>Send EdgeMulti</string>
@@ -735,6 +742,13 @@
           <widget class="QCheckBox" name="checkBox_EdgeMultiNoise">
            <property name="text">
             <string>Noise</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QCheckBox" name="checkBox_edgeMultiTriggerOnError">
+           <property name="text">
+            <string>Trigger On Error Channels</string>
            </property>
           </widget>
          </item>

--- a/observe.py
+++ b/observe.py
@@ -244,7 +244,7 @@ class CountRateMap(QtWidgets.QWidget):
             else:
                 x = scale*xy[i][0]
                 y = scale*xy[i][1]
-            self.addButton(x, y, scale-1, scale-1, name)
+            self.addButton(x, y, scale-1, scale-1, "{}, row{}col{} matterchan{}".format(name,row,col,2*(self.rows*col+row)+1))
             row += 1
             if row >= self.rows:
                 row = 0
@@ -253,7 +253,8 @@ class CountRateMap(QtWidgets.QWidget):
     def setCountRates(self, countRates, colorScale):
         colorScale = float(colorScale)
         assert(len(countRates) == len(self.buttons))
-        cmap = cm.get_cmap('plasma')
+        # cmap = cm.get_cmap('YlOrRd')
+        cmap = cm.get_cmap('Wistia')
         for i, cr in enumerate(countRates):
             button = self.buttons[i]
             if button is None:

--- a/observe.ui
+++ b/observe.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="GridTab">
         <attribute name="title">

--- a/rpc_client.py
+++ b/rpc_client.py
@@ -9,6 +9,7 @@ class JSONClient(object):
 
     def __init__(self, addr, codec=json, qtParent = None):
         self._socket = socket.create_connection(addr)
+        self._socket.settimeout(7.0)
         self._id_iter = itertools.count()
         self._codec = codec
         self._closed = False
@@ -60,9 +61,11 @@ class JSONClient(object):
             if errorBox and self.qtParent is not None:
                 em = QtWidgets.QErrorMessage(self.qtParent)
                 em.showMessage(message)
-            if throwError:
+            elif throwError:
                 raise Exception(message)
-        return response.get('result')
+            else:
+                print "PANIC unhandled response.get(error)"
+        return response.get('result'), response.get("error")
 
     def close(self):
         if not self._closed:


### PR DESCRIPTION
Mostly stuff I thought was already in small_fixes

- improve error handling from rpc errors
- check box to turn on/off error channel triggers for EdgeMulti
- change observe to grid (from map) by default
- handle channel name != channel index when sending projectors
- add a timeout to the rpc socket
- some progress towards an auto-restart button from lancero source
- some workflow filename fixes and change to use the TSVDmass with 7 projectors