### PR TITLE
external trigger rate display, experimental buttons for state labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dastard-commander.creator
 dastard-commander.creator.*
 dastard-commander.files
 dastard-commander.includes
+noise_ana_autocorr_input_simpulses
+noise_analysis_autocorr_input

--- a/dc.ui
+++ b/dc.ui
@@ -92,7 +92,7 @@
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
          <widget class="QComboBox" name="dataSource">
-          <property name="currentText">
+          <property name="currentText" stdset="0">
            <string>Simulated pulse source</string>
           </property>
           <property name="currentIndex">
@@ -814,6 +814,57 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+       </widget>
+       <widget class="QWidget" name="horizontalLayoutWidget_2">
+        <property name="geometry">
+         <rect>
+          <x>30</x>
+          <y>360</y>
+          <width>387</width>
+          <height>41</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLineEdit" name="lineEdit_experimentStateLabel"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_sendExperimentStateLabel">
+           <property name="text">
+            <string>Send Experiment State Label</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="horizontalLayoutWidget_3">
+        <property name="geometry">
+         <rect>
+          <x>30</x>
+          <y>410</y>
+          <width>481</width>
+          <height>41</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item>
+          <widget class="QLineEdit" name="lineEdit_unpauseExperimentalLabel"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_pauseExperimental">
+           <property name="text">
+            <string>Pause</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_unpauseExperimental">
+           <property name="text">
+            <string>Unpause And Send State Label</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </widget>
       <widget class="QWidget" name="tabObserve">

--- a/observe.py
+++ b/observe.py
@@ -187,6 +187,10 @@ class Observe(QtWidgets.QWidget):
         print self.pixelMap
         self.buildCRMMap()
 
+    def handleExternalTriggerMessage(self, msg):
+        n = msg["NumberObservedInLastSecond"]
+        self.ui.label_externalTriggersInLastSecond.setText("{} external triggers in last second".format(n))
+
 
 class CountRateMap(QtWidgets.QWidget):
     """Provide the UI inside the Triggering tab.

--- a/observe.ui
+++ b/observe.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>768</width>
-    <height>578</height>
+    <height>601</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -173,6 +173,13 @@
       </layout>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_externalTriggersInLastSecond">
+     <property name="text">
+      <string>??? external triggers in last second</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
1. Adds a textlabel on the bottom of the observe tab showing the number of external triggers in last second
2. Adds buttons to the Experimental tab to allow setting experiment state labels
3. adds "EXTERNALTRIGGER" to the list of quieted messages